### PR TITLE
add api key to  swaqgger docs

### DIFF
--- a/src/task/task.controller.ts
+++ b/src/task/task.controller.ts
@@ -10,7 +10,7 @@ import {
 } from '@nestjs/common';
 import { CreateTaskDto } from './dto/create-task.dto';
 import { TaskService } from './task.service';
-import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiHeader, ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { Task } from './task.model';
 import { RemoveTaskDto } from './dto/remove-task.dto';
 import { ApiGuard } from '../guards/api/api.guard';
@@ -21,14 +21,23 @@ export class TaskController {
   constructor(private taskService: TaskService) {}
 
   @UseGuards(ApiGuard)
+  @ApiHeader({
+    name: 'apikey',
+    description: 'apikey',
+  })
   @ApiOperation({ summary: 'Create Task' })
   @ApiResponse({ status: 200, type: Task })
+
   @Post('create')
   create(@Body() dto: CreateTaskDto) {
     return this.taskService.createTask(dto);
   }
 
   @UseGuards(ApiGuard)
+  @ApiHeader({
+    name: 'apikey',
+    description: 'apikey',
+  })
   @ApiOperation({ summary: 'Create many Task ' })
   @ApiResponse({ status: 200, type: [Task] })
   @Post('createMany')
@@ -66,6 +75,10 @@ export class TaskController {
 
   @Post('remove')
   @UseGuards(ApiGuard)
+  @ApiHeader({
+    name: 'apikey',
+    description: 'apikey',
+  })
   @HttpCode(200)
   @ApiBody({ type: RemoveTaskDto })
   removeTask(@Body() removeTaskDto: RemoveTaskDto, @Req() req) {

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -9,7 +9,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiHeader, ApiOperation, ApiTags } from "@nestjs/swagger";
 
 import { AuthUserDto } from '../auth/dto/auth-user.dto';
 import { ApiGuard } from '../guards/api/api.guard';
@@ -26,6 +26,10 @@ export class UsersController {
   }
 
   @UseGuards(ApiGuard)
+  @ApiHeader({
+    name: 'apikey',
+    description: 'apikey',
+  })
   @ApiOperation({ summary: 'Get User' })
   @HttpCode(200)
   @Get('all')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced API documentation by requiring an `apikey` header for specific endpoints in the Task and Users controllers.
  
- **Bug Fixes**
	- Improved security measures for accessing the `create`, `createMany`, `removeTask`, and `getAll` endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->